### PR TITLE
Use REACT_APP_ naming convention so env variables are automatically loaded client side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/src/index.js
+++ b/src/index.js
@@ -3,18 +3,17 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
-
 import firebase from 'firebase/app'
 
 var firebaseConfig = {
-    apiKey: process.env.API_KEY,
-    authDomain: process.env.PROJECT_ID + ".firebaseapp.com",
-    databaseURL: "https://" + process.env.PROJECT_ID + "-default-rtdb.firebaseio.com",
-    projectId: process.env.PROJECT_ID,
-    storageBucket: process.env.PROJECT_ID + ".appspot.com",
-    messagingSenderId: process.env.SENDER_ID,
-    appId: process.env.APP_ID,
-    measurementId: process.env.MEASUREMENT_ID
+    apiKey: process.env.REACT_APP_API_KEY,
+    authDomain: process.env.REACT_APP_PROJECT_ID + ".firebaseapp.com",
+    databaseURL: "https://" + process.env.REACT_APP_PROJECT_ID + "-default-rtdb.firebaseio.com",
+    projectId: process.env.REACT_APP_PROJECT_ID,
+    storageBucket: process.env.REACT_APP_PROJECT_ID + ".appspot.com",
+    messagingSenderId: process.env.REACT_APP_SENDER_ID,
+    appId: process.env.REACT_APP_APP_ID,
+    measurementId: process.env.REACT_APP_MEASUREMENT_ID
 };
 
 firebase.initializeApp(firebaseConfig);


### PR DESCRIPTION
env variables were only defined for server-side use -- we need them client side.

Using the REACT_APP_ naming convention allows us to leverage existing functionality to have those variables automatically loaded in the client. See: https://create-react-app.dev/docs/adding-custom-environment-variables

Also added .env to our .gitignore so we can save keys in a file for use locally.